### PR TITLE
Link to COVIDcast API documentation site

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,10 @@ Individual data entries include the following fields:
 
 `geo_value` | `time_value` | `direction` | `value` | `stderr` | `sample_size`
 
-To learn about the valid parameters and fields used in the Delphi's COVIDcast data, please visit the [Delphi Epidata GitHub repository](https://github.com/cmu-delphi/delphi-epidata/blob/master/docs/api/covidcast.md) where this project is actively maintained.
+To learn about the valid parameters and fields used in the Delphi's COVIDcast data, please visit the [COVIDcast API documentation](https://cmu-delphi.github.io/delphi-epidata/api/covidcast.html) and the [Delphi Epidata GitHub repository](https://github.com/cmu-delphi/delphi-epidata/blob/master/docs/api/covidcast.md) where this project is actively maintained.
 
 ## More Information
+- [Delphi COVIDcast API source and signal documentation](https://cmu-delphi.github.io/delphi-epidata/api/covidcast_signals.html)
 - [Source: Delphi Epidata | An open API for Epidemiological Data](https://github.com/cmu-delphi/delphi-epidata)
 - [Home Page: Delphi Research Group | Carnegie Mellon University](https://delphi.cmu.edu)
 - [COVIDcast | Carnegie Mellon University](https://covidcast.cmu.edu)


### PR DESCRIPTION
This PR adds the Delphi COVIDcast API documentation link directly to the README, so users can see the full technical descriptions of the signals and how they are estimated. (We built up this documentation over the past couple weeks, so much of it is new.) Thanks for maintaining this resource for others to use Delphi's data!